### PR TITLE
UI cleanup and bug fixes

### DIFF
--- a/fe_poker/App.tsx
+++ b/fe_poker/App.tsx
@@ -49,7 +49,7 @@ function HomeStack() {
       }}
     >
       <Stack.Screen name="Home" component={HomeScreen} options={{ headerShown: false }} />
-      <Stack.Screen name="HandDetail" component={HandDetailScreen} options={{ title: 'Hand Details', headerBackTitle: 'Back' }} />
+      <Stack.Screen name="HandDetail" component={HandDetailScreen} options={{ title: 'Back', headerBackTitle: 'Back' }} />
       <Stack.Screen name="NewSession" component={NewSessionScreen} options={{ title: 'New Session', headerBackTitle: 'Back' }} />
       <Stack.Screen name="RecordHand" component={RecordHandScreen} options={{ title: 'Record Hand', headerBackTitle: 'Back' }} />
       <Stack.Screen name="EditHand" component={EditHandScreen} options={{ title: 'Edit Hand' }} />
@@ -79,7 +79,7 @@ const SessionsStack = () => (
     <Stack.Screen name="EditSession" component={EditSessionScreen} options={{ title: 'Edit Session' }} />
     <Stack.Screen name="RecordHand" component={RecordHandScreen} options={{ title: 'Record Hand', headerBackTitle: 'Back' }} />
     <Stack.Screen name="EditHand" component={EditHandScreen} options={{ title: 'Edit Hand' }} />
-    <Stack.Screen name="HandDetail" component={HandDetailScreen} options={{ title: 'Hand Details' }} />
+    <Stack.Screen name="HandDetail" component={HandDetailScreen} options={{ title: 'Back' }} />
     <Stack.Screen name="AIAnalysis" component={AIAnalysisScreen} options={{ title: 'GTO Analysis' }} />
     <Stack.Screen 
       name="PokerKeyboard" 

--- a/fe_poker/react-native.config.js
+++ b/fe_poker/react-native.config.js
@@ -4,4 +4,15 @@ module.exports = {
     android: {},
   },
   assets: ['./src/assets/fonts/'],
+  dependencies: {
+    'react-native-sqlite-storage': {
+      platforms: {
+        android: {
+          sourceDir: '../node_modules/react-native-sqlite-storage/platforms/android',
+          packageImportPath: 'import org.pgsqlite.SQLitePluginPackage;',
+        },
+        // iOS 配置被省略，讓 React Native 自動處理
+      },
+    },
+  },
 }; 

--- a/fe_poker/src/screens/EditHandScreen.tsx
+++ b/fe_poker/src/screens/EditHandScreen.tsx
@@ -509,11 +509,7 @@ export const EditHandScreen: React.FC<{ navigation: any; route: any }> = ({ navi
         <View style={styles.topSection}>
           <View style={styles.fieldColumn}>
             <View style={styles.labelRow}>
-              <Text style={styles.label}>Hand Details</Text>
-              {/* Debug Info */}
-              <View style={{ backgroundColor: '#f0f0f0', padding: 4, borderRadius: 4, marginHorizontal: 8 }}>
-                <Text style={{ fontSize: 10, color: '#666' }}>Cursor: {selection.start}-{selection.end} | Len: {details.length}</Text>
-              </View>
+              <View style={{ flex: 1 }} />
               <View style={styles.keyboardToggleContainer}>
                 <Text style={styles.toggleLabel}>Poker Keyboard</Text>
                 <Switch


### PR DESCRIPTION
## Summary
- Clean up EditHandScreen debug information and layout
- Fix SQLite configuration warnings
- Remove duplicate UI elements for better user experience

## Changes Made
- **Remove debug info**: Removed cursor position debug information from EditHandScreen
- **Clean UI layout**: Removed duplicate "Hand Details" label to prevent confusion
- **Maintain UX**: Kept Poker Keyboard toggle positioned on the right side
- **Fix warnings**: Added proper SQLite configuration to suppress React Native warnings

## Test Plan
- [x] Verify EditHandScreen displays cleanly without debug info
- [x] Confirm Poker Keyboard toggle is positioned correctly
- [x] Test that SQLite functionality works without warnings
- [x] Ensure no duplicate labels are shown

🤖 Generated with [Claude Code](https://claude.ai/code)