### PR TITLE
feat: set default location to 'Live Casino' for new users

### DIFF
--- a/fe_poker/__tests__/NewSessionScreen.test.tsx
+++ b/fe_poker/__tests__/NewSessionScreen.test.tsx
@@ -36,7 +36,7 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
 jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
 
 const mockPreferences = {
-  lastLocation: 'Live Casino',
+  lastLocation: '',
   lastCurrency: 'USD ($)',
   lastTableSize: '6',
   lastBlinds: '1/2',
@@ -124,6 +124,21 @@ describe('NewSessionScreen', () => {
     
     await waitFor(() => {
       expect(getByText('格式：小盲注/大盲注 (例如: 1/2, 0.5/1)')).toBeTruthy();
+    });
+  });
+
+  it('defaults to Live Casino when user has no previous location', async () => {
+    // Use empty lastLocation to simulate new user
+    const emptyPreferences = {
+      ...mockPreferences,
+      lastLocation: '',
+    };
+    (UserPreferencesService.getPreferences as jest.Mock).mockResolvedValue(emptyPreferences);
+
+    const { getByDisplayValue } = render(<NewSessionScreen navigation={mockNavigation} />);
+    
+    await waitFor(() => {
+      expect(getByDisplayValue('Live Casino')).toBeTruthy();
     });
   });
 }); 

--- a/fe_poker/src/components/SessionForm.tsx
+++ b/fe_poker/src/components/SessionForm.tsx
@@ -84,7 +84,7 @@ export const SessionForm: React.FC<SessionFormProps> = ({
       const formattedDate = `${now.getFullYear()}/${String(now.getMonth() + 1).padStart(2, '0')}/${String(now.getDate()).padStart(2, '0')} ${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
       
       setFormData({
-        location: prefs.lastLocation || '',
+        location: prefs.lastLocation || 'Live Casino',
         date: formattedDate,
         blinds: prefs.lastBlinds || '1/2',
         currency: prefs.lastCurrency || '🇺🇸 USD ($)',


### PR DESCRIPTION
## Summary
- Set default location to "Live Casino" for new users when creating sessions
- Existing users continue to see their previously used location
- Improved first-time user experience by providing a sensible default

## Changes Made
- Updated `SessionForm.tsx` to use "Live Casino" as fallback when `lastLocation` is empty
- Added test coverage for the default location behavior
- Updated existing test mock data to properly test new user scenario

## Test Plan
- [x] Verified logic with JavaScript test simulation
- [x] Updated test cases to cover new user scenario  
- [x] Ensured backward compatibility for existing users
- [x] Confirmed no lint or type errors introduced

## User Experience Impact
- **Before**: New users see empty location field, must enter manually
- **After**: New users see "Live Casino" as default, can use immediately or change as needed
- **Existing users**: No change - still see their last used location

🤖 Generated with [Claude Code](https://claude.ai/code)