### PR TITLE
fix: correct AI hand analysis to interpret amounts as currency not BB

### DIFF
--- a/be_poker/handlers/hand.go
+++ b/be_poker/handlers/hand.go
@@ -330,7 +330,23 @@ func AnalyzeHand(w http.ResponseWriter, r *http.Request) {
 		board = *hand.Board
 	}
 	
-	analysis, err := openaiService.AnalyzeHand(hand.Details, hand.Result, position, holeCards, board, hand.Villains)
+	// 獲取session信息以取得盲注設定
+	var smallBlind, bigBlind int
+	sessionRow := db.DB.QueryRow(`
+		SELECT 
+			COALESCE(small_blind, 0), 
+			COALESCE(big_blind, 0)
+		FROM sessions 
+		WHERE id = $1
+	`, hand.SessionID)
+	
+	err = sessionRow.Scan(&smallBlind, &bigBlind)
+	if err != nil {
+		http.Error(w, "Failed to get session info for analysis: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	
+	analysis, err := openaiService.AnalyzeHand(hand.Details, hand.Result, position, holeCards, board, hand.Villains, smallBlind, bigBlind)
 	if err != nil {
 		http.Error(w, "Analysis failed: "+err.Error(), http.StatusInternalServerError)
 		return

--- a/be_poker/prompts/hand_analysis.txt
+++ b/be_poker/prompts/hand_analysis.txt
@@ -1,5 +1,14 @@
 You are a professional poker GTO coach. Please analyze the following poker hand in the style of GTOWizard.
 
+Session Information:
+- Small Blind: {{SMALL_BLIND}}
+- Big Blind: {{BIG_BLIND}}
+
+CRITICAL: All monetary amounts in the hand details are ACTUAL CURRENCY AMOUNTS, not big blind multiples. 
+For example, if you see "20" in the action, it means 20 in actual currency, not 20BB.
+To convert to big blinds: Amount ÷ {{BIG_BLIND}} = BB
+(e.g., if Big Blind is 2 and you see "20", that equals 10BB)
+
 Hand Details: {{HAND_DETAILS}}
 Result: {{RESULT}}
 

--- a/be_poker/services/openai_service.go
+++ b/be_poker/services/openai_service.go
@@ -24,13 +24,14 @@ func NewOpenAIService() *OpenAIService {
 	return &OpenAIService{client: client}
 }
 
-func (s *OpenAIService) AnalyzeHand(handDetails string, result int, position string, holeCards string, board string, villains []models.Villain) (string, error) {
+func (s *OpenAIService) AnalyzeHand(handDetails string, result int, position string, holeCards string, board string, villains []models.Villain, smallBlind int, bigBlind int) (string, error) {
 	if s.client == nil {
 		return "", fmt.Errorf("OpenAI service not available: API key not set")
 	}
 
 	// 組合完整的手牌信息
 	var fullHandDetails strings.Builder
+	fullHandDetails.WriteString(fmt.Sprintf("Session Blinds: %d/%d\n", smallBlind, bigBlind))
 	fullHandDetails.WriteString(fmt.Sprintf("Hero Position: %s\n", position))
 	fullHandDetails.WriteString(fmt.Sprintf("Hero Hole Cards: %s\n", holeCards))
 	fullHandDetails.WriteString(fmt.Sprintf("Board: %s\n", board))
@@ -48,7 +49,7 @@ func (s *OpenAIService) AnalyzeHand(handDetails string, result int, position str
 	
 	// 使用prompt管理器獲取prompt
 	promptManager := NewPromptManager()
-	prompt, err := promptManager.GetHandAnalysisPrompt(fullHandDetails.String(), result)
+	prompt, err := promptManager.GetHandAnalysisPrompt(fullHandDetails.String(), result, smallBlind, bigBlind)
 	if err != nil {
 		// 錯誤處理：記錄錯誤並使用fallback prompt
 		fmt.Printf("Error reading prompt file: %v\n", err)

--- a/be_poker/services/prompt_manager.go
+++ b/be_poker/services/prompt_manager.go
@@ -18,7 +18,7 @@ func NewPromptManager() *PromptManager {
 }
 
 // 讀取prompt文件並替換變數
-func (pm *PromptManager) GetHandAnalysisPrompt(handDetails string, result int) (string, error) {
+func (pm *PromptManager) GetHandAnalysisPrompt(handDetails string, result int, smallBlind int, bigBlind int) (string, error) {
 	promptPath := filepath.Join(pm.promptsDir, "hand_analysis.txt")
 	
 	// 讀取prompt文件
@@ -31,6 +31,9 @@ func (pm *PromptManager) GetHandAnalysisPrompt(handDetails string, result int) (
 	prompt := string(content)
 	prompt = strings.ReplaceAll(prompt, "{{HAND_DETAILS}}", handDetails)
 	prompt = strings.ReplaceAll(prompt, "{{RESULT}}", fmt.Sprintf("%+d", result))
+	prompt = strings.ReplaceAll(prompt, "{{SMALL_BLIND}}", fmt.Sprintf("%d", smallBlind))
+	prompt = strings.ReplaceAll(prompt, "{{BIG_BLIND}}", fmt.Sprintf("%d", bigBlind))
+	prompt = strings.ReplaceAll(prompt, "{{LANGUAGE}}", "Traditional Chinese")
 	
 	return prompt, nil
 }


### PR DESCRIPTION
The GPT was incorrectly interpreting monetary amounts in hand details as big blind multiples instead of actual currency amounts. For example, "20" was being treated as 20BB instead of $20.

Changes:
- Add session blind info to OpenAI analysis request
- Update prompt template to clarify amount vs BB distinction
- Modify all related functions to pass smallBlind/bigBlind parameters
- Include explicit conversion formula in prompt: Amount ÷ BigBlind = BB

Now if user inputs "20" with $2 big blind, GPT correctly calculates 10BB.

🤖 Generated with [Claude Code](https://claude.ai/code)