### PR TITLE
Add Xcode Cloud post-clone script

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+cd fe_poker
+npm ci
+cd ios
+pod install


### PR DESCRIPTION
## Summary
- install npm dependencies and pods in Xcode Cloud after cloning

## Testing
- `cd fe_poker && npm test` *(fails: Cannot find module '@react-native-community/datetimepicker')*


------
https://chatgpt.com/codex/tasks/task_e_68a21d31905c8320b410d06a68478735